### PR TITLE
Match both single and double quotation in markdown

### DIFF
--- a/htmlemailer/__init__.py
+++ b/htmlemailer/__init__.py
@@ -118,7 +118,7 @@ def render_from_markdown(template, template_context):
 
         # fix the {% extends "..." %} file extension.
         r = re.sub(
-            r"^(\s*\{%\s*extends\s+\"[^\"]*)(\"\s*%\})",
+            r"^(\s*\{%\s*extends\s+[\"'][^\"']*)([\"']\s*%\})",
             lambda m : m.group(1) + "." + ext + m.group(2),
             r)
 


### PR DESCRIPTION
The regex for adding file extension to the markdown matches `{% extends "blah" %}`, but not `{% extends 'blah' %}` although both are valid Django template syntax. This PR fixes this bug.